### PR TITLE
[FEA] Added the requirements for gym and pyglet and updated TD3

### DIFF
--- a/TD3.py
+++ b/TD3.py
@@ -27,7 +27,7 @@ class ReplayBuffer:
         self.action_memory = np.zeros((self.mem_size, dim_actions),
                                       dtype=np.float32)
         self.reward_memory = np.zeros(self.mem_size, dtype=np.float32)
-        self.terminal_memory = np.zeros(self.mem_size, dtype=np.bool)
+        self.terminal_memory = np.zeros(self.mem_size, dtype=np.bool_)
 
     def store_transition(self, state, action, reward, new_state, done):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ imageio
 wheel
 torch
 numpy
-gym
+gym==0.21.0
 matplotlib
-pyglet
+pyglet==1.5.27
 PyOpenGL
 flake8
 scipy


### PR DESCRIPTION
Hello Kanish, While running the test file, I encountered some compatibility issues for `gym` and `pyglet`, which I've updated the versions in the requirements, and there is a deprecated function in the `TD3.py` file of `numpy.bool` which is now called as `np.bool_` .